### PR TITLE
Further edits to distance transform

### DIFF
--- a/gunpowder/contrib/nodes/__init__.py
+++ b/gunpowder/contrib/nodes/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .add_blobs_from_points import AddBlobsFromPoints
 from .add_boundary_distance import AddBoundaryDistance
 from .add_distance import AddDistance
-from .add_distance_WIP import AddDistanceWIP
+from .add_distance_isotropic import AddDistanceIsotropic
 from .add_pre_post_cleft_distance import AddPrePostCleftDistance
 from .add_boundary_distance_gradients import AddBoundaryDistanceGradients
 from .add_gt_mask_exclusive_zone import AddGtMaskExclusiveZone

--- a/gunpowder/contrib/nodes/add_distance_WIP.py
+++ b/gunpowder/contrib/nodes/add_distance_WIP.py
@@ -158,6 +158,6 @@ class AddDistanceWIP(BatchFilter):
         tmp[slices] = mask[slices]
         boundary_distance = distance_transform_edt(tmp, sampling=mask_sampling)
         mask_output = mask.copy()
-        mask_output[distances > boundary_distance] = 0
+        mask_output[abs(distances) > boundary_distance] = 0
 
         return mask_output

--- a/gunpowder/contrib/nodes/add_distance_WIP.py
+++ b/gunpowder/contrib/nodes/add_distance_WIP.py
@@ -153,10 +153,11 @@ class AddDistanceWIP(BatchFilter):
     def __constrain_distances(mask, distances, mask_sampling):
         # remove elements from the mask where the label distances exceed the distance from the boundary
 
-        tmp = np.zeros(mask.shape, dtype=mask.dtype)
+        tmp = np.zeros(np.array(mask.shape) + np.array((2,)*mask.ndim), dtype=mask.dtype)
         slices = tmp.ndim * (slice(1, -1),)
-        tmp[slices] = mask[slices]
+        tmp[slices] = mask
         boundary_distance = distance_transform_edt(tmp, sampling=mask_sampling)
+        boundary_distance = boundary_distance[slices]
         mask_output = mask.copy()
         mask_output[abs(distances) > boundary_distance] = 0
 

--- a/gunpowder/contrib/nodes/add_distance_WIP.py
+++ b/gunpowder/contrib/nodes/add_distance_WIP.py
@@ -65,7 +65,6 @@ class AddDistanceWIP(BatchFilter):
         spec.dtype = np.float32
         spec.voxel_size *= self.factor
         self.provides(self.distance_array_key, spec)
-        self.provides(self.mask_array_key, spec)
 
     def prepare(self, request):
 

--- a/gunpowder/contrib/nodes/add_distance_isotropic.py
+++ b/gunpowder/contrib/nodes/add_distance_isotropic.py
@@ -8,7 +8,7 @@ from gunpowder.nodes.batch_filter import BatchFilter
 logger = logging.getLogger(__name__)
 
 
-class AddDistanceWIP(BatchFilter):
+class AddDistanceIsotropic(BatchFilter):
     '''Compute array with signed distances from specific labels
 
     Args:
@@ -63,6 +63,7 @@ class AddDistanceWIP(BatchFilter):
 
         spec = self.spec[self.label_array_key].copy()
         spec.dtype = np.float32
+        assert len(set(spec.voxel_size)) == 1, "This node only works with isotropic data"
         spec.voxel_size *= self.factor
         self.provides(self.distance_array_key, spec)
 
@@ -140,7 +141,7 @@ class AddDistanceWIP(BatchFilter):
         # between the distance transform of the label ("inner distances") and the distance transform of
         # the complement of the label ("outer distances"). To compensate for an edge effect, .5 (half a pixel's
         # distance) is added to the positive distances and subtracted from the negative distances.
-        tweak = .5
+        tweak = kwargs['sampling'][0]*.5
         inner_distance = distance_transform_edt(label, **kwargs)
         outer_distance = distance_transform_edt(np.logical_not(label), **kwargs)
         result = inner_distance - outer_distance


### PR DESCRIPTION
- minor fixes
- restrict use of node for arrays with isotropic resolution
- when computing the distance transform of the mask for finding potentially invalid distances, add boundary  outside the original patch instead of using the last pixel within the original patch as the boundary